### PR TITLE
Fix laggy sensor readings

### DIFF
--- a/adafruit_bno08x_rvc.py
+++ b/adafruit_bno08x_rvc.py
@@ -121,6 +121,7 @@ class BNO08x_RVC:
 
         """
         # try to read initial packet start byte
+        self._uart.reset_input_buffer()
         data = None
         start_time = time.monotonic()
         while time.monotonic() - start_time < self._read_timeout:


### PR DESCRIPTION
Fix for #8.

Tested on a host PC (linux) running Blinka with BNO080 in RVC mode connected via a USB serial cable.

Running the `bno08x_rvc_simpletest.py` example and moving the BNO080 around:
```
Yaw: 48.87 Pitch: 53.74 Roll: -42.84 Degrees
Acceleration X: 3.53 Y: 10.78 Z: 5.22 m/s^2

Yaw: 72.21 Pitch: 10.53 Roll: -3.19 Degrees
Acceleration X: 0.88 Y: -1.42 Z: 8.51 m/s^2

Yaw: 48.20 Pitch: -77.66 Roll: 20.54 Degrees
Acceleration X: 1.30 Y: -13.22 Z: 8.74 m/s^2

Yaw: -123.97 Pitch: -39.02 Roll: 156.02 Degrees
Acceleration X: -3.80 Y: -12.31 Z: -9.74 m/s^2

Yaw: -157.34 Pitch: 12.85 Roll: 150.78 Degrees
Acceleration X: -5.22 Y: -2.03 Z: -3.33 m/s^2

Yaw: -172.79 Pitch: 35.50 Roll: 129.35 Degrees
Acceleration X: -5.75 Y: 3.83 Z: -3.53 m/s^2

Yaw: -170.95 Pitch: 22.51 Roll: 170.67 Degrees
Acceleration X: -5.98 Y: 4.22 Z: -10.54 m/s^2
```

Readings now update as expected.